### PR TITLE
Externalize menu items for localization

### DIFF
--- a/app/src/main/java/ru/sergeipavlov/metrology/MainActivity.java
+++ b/app/src/main/java/ru/sergeipavlov/metrology/MainActivity.java
@@ -28,12 +28,7 @@ public class MainActivity extends AppCompatActivity {
 
         RecyclerView recyclerView = findViewById(R.id.recycler_view);
         recyclerView.setLayoutManager(new LinearLayoutManager(this));
-        List<String> items = Arrays.asList(
-                "Единицы измерения",
-                "Шкала-сигнал",
-                "Датчики температуры",
-                "Сужающие устройства"
-        );
+        List<String> items = Arrays.asList(getResources().getStringArray(R.array.main_menu_items));
         recyclerView.setAdapter(new MainAdapter(items));
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,10 @@
 <resources>
     <string name="app_name">Metrology</string>
+
+    <string-array name="main_menu_items">
+        <item>Единицы измерения</item>
+        <item>Шкала-сигнал</item>
+        <item>Датчики температуры</item>
+        <item>Сужающие устройства</item>
+    </string-array>
 </resources>


### PR DESCRIPTION
## Summary
- move RecyclerView menu strings into `main_menu_items` string-array resource
- load menu items from resources in `MainActivity` for localization readiness

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy, HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b4450428fc83209d49f3ffa0979964