### PR TITLE
Ensure temperature conversion outputs three decimals

### DIFF
--- a/app/src/main/java/ru/sergeipavlov/metrology/MainActivity.java
+++ b/app/src/main/java/ru/sergeipavlov/metrology/MainActivity.java
@@ -68,8 +68,7 @@ public class MainActivity extends AppCompatActivity {
 
             try {
                 double value = Double.parseDouble(text);
-                int precision = Math.max(getDecimals(text), 3);
-                String format = "%" + "." + precision + "f";
+                String format = "%.3f";
 
                 double celsius;
                 double fahrenheit;
@@ -113,9 +112,4 @@ public class MainActivity extends AppCompatActivity {
         }
     }
 
-    private int getDecimals(String text) {
-        int index = text.indexOf('.') ;
-        if (index < 0) return 0;
-        return text.length() - index - 1;
-    }
 }


### PR DESCRIPTION
## Summary
- always format converted temperatures with three fractional digits
- remove unused precision helper

## Testing
- `sh gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68b5eddcf09c8320b45c33fa0539e921