### PR TITLE
Initialize temperature fields to 0 Kelvin

### DIFF
--- a/app/src/main/java/ru/sergeipavlov/metrology/MainActivity.java
+++ b/app/src/main/java/ru/sergeipavlov/metrology/MainActivity.java
@@ -15,6 +15,8 @@ import java.util.Locale;
 
 public class MainActivity extends AppCompatActivity {
 
+    private static final String FORMAT = "%.3f";
+
     private EditText etCelsius;
     private EditText etFahrenheit;
     private EditText etKelvin;
@@ -38,6 +40,9 @@ public class MainActivity extends AppCompatActivity {
         etCelsius.addTextChangedListener(new TemperatureWatcher(etCelsius));
         etFahrenheit.addTextChangedListener(new TemperatureWatcher(etFahrenheit));
         etKelvin.addTextChangedListener(new TemperatureWatcher(etKelvin));
+
+        etKelvin.setText(String.format(Locale.US, FORMAT, 0.0));
+        etKelvin.setSelection(etKelvin.getText().length());
     }
 
     private class TemperatureWatcher implements TextWatcher {
@@ -68,7 +73,6 @@ public class MainActivity extends AppCompatActivity {
 
             try {
                 double value = Double.parseDouble(text);
-                String format = "%.3f";
 
                 double celsius;
                 double fahrenheit;
@@ -90,15 +94,15 @@ public class MainActivity extends AppCompatActivity {
 
                 isUpdating = true;
                 if (source != etCelsius) {
-                    etCelsius.setText(String.format(Locale.US, format, celsius));
+                    etCelsius.setText(String.format(Locale.US, FORMAT, celsius));
                     etCelsius.setSelection(etCelsius.getText().length());
                 }
                 if (source != etFahrenheit) {
-                    etFahrenheit.setText(String.format(Locale.US, format, fahrenheit));
+                    etFahrenheit.setText(String.format(Locale.US, FORMAT, fahrenheit));
                     etFahrenheit.setSelection(etFahrenheit.getText().length());
                 }
                 if (source != etKelvin) {
-                    etKelvin.setText(String.format(Locale.US, format, kelvin));
+                    etKelvin.setText(String.format(Locale.US, FORMAT, kelvin));
                     etKelvin.setSelection(etKelvin.getText().length());
                 }
                 isUpdating = false;


### PR DESCRIPTION
## Summary
- Initialize the temperature converter with 0 K so Celsius and Fahrenheit fields are auto-populated
- Centralize three-decimal formatting for consistent precision

## Testing
- `bash ./gradlew test` *(fails: Unable to tunnel through proxy, HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b5efe9694c832081f043c594e72437