### PR TITLE
Fix unit conversion screen navigation

### DIFF
--- a/app/src/main/java/ru/sergeipavlov/metrology/UnitsActivity.java
+++ b/app/src/main/java/ru/sergeipavlov/metrology/UnitsActivity.java
@@ -30,13 +30,22 @@ public class UnitsActivity extends BaseActivity {
         recyclerView.setLayoutManager(new LinearLayoutManager(this));
 
         List<UnitsAdapter.Item> items = new ArrayList<>();
-        items.add(new UnitsAdapter.Item(true, getString(R.string.base_units_title)));
-        for (String unit : getResources().getStringArray(R.array.base_units)) {
-            items.add(new UnitsAdapter.Item(false, unit));
+        items.add(new UnitsAdapter.Item(true, getString(R.string.base_units_title), null));
+        String[] baseUnits = getResources().getStringArray(R.array.base_units);
+        for (int i = 0; i < baseUnits.length; i++) {
+            Class<?> activity = null;
+            if (i == 0) {
+                activity = TimeActivity.class;
+            } else if (i == 3) {
+                activity = CurrentActivity.class;
+            } else if (i == 4) {
+                activity = TemperatureActivity.class;
+            }
+            items.add(new UnitsAdapter.Item(false, baseUnits[i], activity));
         }
-        items.add(new UnitsAdapter.Item(true, getString(R.string.derived_units_title)));
+        items.add(new UnitsAdapter.Item(true, getString(R.string.derived_units_title), null));
         for (String unit : getResources().getStringArray(R.array.derived_units)) {
-            items.add(new UnitsAdapter.Item(false, unit));
+            items.add(new UnitsAdapter.Item(false, unit, null));
         }
 
         recyclerView.setAdapter(new UnitsAdapter(items));

--- a/app/src/main/java/ru/sergeipavlov/metrology/UnitsAdapter.java
+++ b/app/src/main/java/ru/sergeipavlov/metrology/UnitsAdapter.java
@@ -17,10 +17,12 @@ public class UnitsAdapter extends RecyclerView.Adapter<UnitsAdapter.ViewHolder> 
     static class Item {
         final boolean isHeader;
         final String text;
+        final Class<?> activity;
 
-        Item(boolean isHeader, String text) {
+        Item(boolean isHeader, String text, Class<?> activity) {
             this.isHeader = isHeader;
             this.text = text;
+            this.activity = activity;
         }
     }
 
@@ -47,15 +49,12 @@ public class UnitsAdapter extends RecyclerView.Adapter<UnitsAdapter.ViewHolder> 
             holder.itemView.setOnClickListener(null);
         } else {
             holder.textView.setTypeface(null, Typeface.NORMAL);
-            holder.itemView.setOnClickListener(v -> {
-                if ("Время".equals(item.text)) {
-                    v.getContext().startActivity(new Intent(v.getContext(), TimeActivity.class));
-                } else if ("Температура".equals(item.text)) {
-                    v.getContext().startActivity(new Intent(v.getContext(), TemperatureActivity.class));
-                } else if ("Сила тока".equals(item.text)) {
-                    v.getContext().startActivity(new Intent(v.getContext(), CurrentActivity.class));
-                }
-            });
+            if (item.activity != null) {
+                holder.itemView.setOnClickListener(v ->
+                        v.getContext().startActivity(new Intent(v.getContext(), item.activity)));
+            } else {
+                holder.itemView.setOnClickListener(null);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Avoid hard-coded Russian names in units list
- Attach target Activities directly to list items

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68b898c8a44c83209a2f8e0bb21db89c