### PR TITLE
Add mass conversion screen

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,6 +24,9 @@
             android:name=".UnitsActivity"
             android:exported="false" />
         <activity
+            android:name=".MassActivity"
+            android:exported="false" />
+        <activity
             android:name=".TemperatureActivity"
             android:exported="false" />
         <activity

--- a/app/src/main/java/ru/sergeipavlov/metrology/MassActivity.java
+++ b/app/src/main/java/ru/sergeipavlov/metrology/MassActivity.java
@@ -1,0 +1,20 @@
+package ru.sergeipavlov.metrology;
+
+import android.os.Bundle;
+
+import androidx.activity.EdgeToEdge;
+
+public class MassActivity extends BaseActivity {
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        EdgeToEdge.enable(this);
+        setContentView(R.layout.activity_mass);
+        if (savedInstanceState == null) {
+            getSupportFragmentManager()
+                    .beginTransaction()
+                    .replace(R.id.mass_container, new MassFragment())
+                    .commit();
+        }
+    }
+}

--- a/app/src/main/java/ru/sergeipavlov/metrology/MassFragment.java
+++ b/app/src/main/java/ru/sergeipavlov/metrology/MassFragment.java
@@ -1,0 +1,323 @@
+package ru.sergeipavlov.metrology;
+
+import android.os.Bundle;
+import android.text.Editable;
+import android.text.TextWatcher;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.EditText;
+import android.widget.Toast;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+public class MassFragment extends Fragment {
+    private EditText kilogram;
+    private EditText gram;
+    private EditText milligram;
+    private EditText centner;
+    private EditText tonne;
+    private EditText carat;
+    private EditText newton;
+    private EditText stone;
+    private EditText pound;
+    private EditText ounce;
+    private EditText dram;
+    private EditText grain;
+    private EditText shortTon;
+    private EditText shortHundredweight;
+    private EditText longTon;
+    private EditText longHundredweight;
+    private EditText troyPound;
+    private EditText troyOunce;
+    private EditText pennyweight;
+    private EditText mite;
+    private EditText doit;
+    private boolean isUpdating;
+
+    private enum Unit {
+        KILOGRAM, GRAM, MILLIGRAM, CENTNER, TONNE, CARAT, NEWTON,
+        STONE, POUND, OUNCE, DRAM, GRAIN,
+        SHORT_TON, SHORT_HUNDREDWEIGHT, LONG_TON, LONG_HUNDREDWEIGHT,
+        TROY_POUND, TROY_OUNCE, PENNYWEIGHT, MITE, DOIT
+    }
+
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+        View view = inflater.inflate(R.layout.fragment_mass, container, false);
+        kilogram = view.findViewById(R.id.edit_kilogram);
+        gram = view.findViewById(R.id.edit_gram);
+        milligram = view.findViewById(R.id.edit_milligram);
+        centner = view.findViewById(R.id.edit_centner);
+        tonne = view.findViewById(R.id.edit_tonne);
+        carat = view.findViewById(R.id.edit_carat);
+        newton = view.findViewById(R.id.edit_newton);
+        stone = view.findViewById(R.id.edit_stone);
+        pound = view.findViewById(R.id.edit_pound);
+        ounce = view.findViewById(R.id.edit_ounce);
+        dram = view.findViewById(R.id.edit_dram);
+        grain = view.findViewById(R.id.edit_grain);
+        shortTon = view.findViewById(R.id.edit_short_ton);
+        shortHundredweight = view.findViewById(R.id.edit_short_hundredweight);
+        longTon = view.findViewById(R.id.edit_long_ton);
+        longHundredweight = view.findViewById(R.id.edit_long_hundredweight);
+        troyPound = view.findViewById(R.id.edit_troy_pound);
+        troyOunce = view.findViewById(R.id.edit_troy_ounce);
+        pennyweight = view.findViewById(R.id.edit_pennyweight);
+        mite = view.findViewById(R.id.edit_mite);
+        doit = view.findViewById(R.id.edit_doit);
+
+        view.findViewById(R.id.symbol_kilogram).setOnClickListener(v -> showDescription(R.string.desc_kilogram));
+        view.findViewById(R.id.symbol_gram).setOnClickListener(v -> showDescription(R.string.desc_gram));
+        view.findViewById(R.id.symbol_milligram).setOnClickListener(v -> showDescription(R.string.desc_milligram));
+        view.findViewById(R.id.symbol_centner).setOnClickListener(v -> showDescription(R.string.desc_centner));
+        view.findViewById(R.id.symbol_tonne).setOnClickListener(v -> showDescription(R.string.desc_tonne));
+        view.findViewById(R.id.symbol_carat).setOnClickListener(v -> showDescription(R.string.desc_carat));
+        view.findViewById(R.id.symbol_newton).setOnClickListener(v -> showDescription(R.string.desc_newton_force));
+        view.findViewById(R.id.symbol_stone).setOnClickListener(v -> showDescription(R.string.desc_stone));
+        view.findViewById(R.id.symbol_pound).setOnClickListener(v -> showDescription(R.string.desc_pound));
+        view.findViewById(R.id.symbol_ounce).setOnClickListener(v -> showDescription(R.string.desc_ounce));
+        view.findViewById(R.id.symbol_dram).setOnClickListener(v -> showDescription(R.string.desc_dram));
+        view.findViewById(R.id.symbol_grain).setOnClickListener(v -> showDescription(R.string.desc_grain));
+        view.findViewById(R.id.symbol_short_ton).setOnClickListener(v -> showDescription(R.string.desc_short_ton));
+        view.findViewById(R.id.symbol_short_hundredweight).setOnClickListener(v -> showDescription(R.string.desc_short_hundredweight));
+        view.findViewById(R.id.symbol_long_ton).setOnClickListener(v -> showDescription(R.string.desc_long_ton));
+        view.findViewById(R.id.symbol_long_hundredweight).setOnClickListener(v -> showDescription(R.string.desc_long_hundredweight));
+        view.findViewById(R.id.symbol_troy_pound).setOnClickListener(v -> showDescription(R.string.desc_troy_pound));
+        view.findViewById(R.id.symbol_troy_ounce).setOnClickListener(v -> showDescription(R.string.desc_troy_ounce));
+        view.findViewById(R.id.symbol_pennyweight).setOnClickListener(v -> showDescription(R.string.desc_pennyweight));
+        view.findViewById(R.id.symbol_mite).setOnClickListener(v -> showDescription(R.string.desc_mite));
+        view.findViewById(R.id.symbol_doit).setOnClickListener(v -> showDescription(R.string.desc_doit));
+
+        addWatcher(kilogram, Unit.KILOGRAM);
+        addWatcher(gram, Unit.GRAM);
+        addWatcher(milligram, Unit.MILLIGRAM);
+        addWatcher(centner, Unit.CENTNER);
+        addWatcher(tonne, Unit.TONNE);
+        addWatcher(carat, Unit.CARAT);
+        addWatcher(newton, Unit.NEWTON);
+        addWatcher(stone, Unit.STONE);
+        addWatcher(pound, Unit.POUND);
+        addWatcher(ounce, Unit.OUNCE);
+        addWatcher(dram, Unit.DRAM);
+        addWatcher(grain, Unit.GRAIN);
+        addWatcher(shortTon, Unit.SHORT_TON);
+        addWatcher(shortHundredweight, Unit.SHORT_HUNDREDWEIGHT);
+        addWatcher(longTon, Unit.LONG_TON);
+        addWatcher(longHundredweight, Unit.LONG_HUNDREDWEIGHT);
+        addWatcher(troyPound, Unit.TROY_POUND);
+        addWatcher(troyOunce, Unit.TROY_OUNCE);
+        addWatcher(pennyweight, Unit.PENNYWEIGHT);
+        addWatcher(mite, Unit.MITE);
+        addWatcher(doit, Unit.DOIT);
+
+        isUpdating = true;
+        double kg = 0.0;
+        int precision = 3;
+        setAll(kg, precision);
+        isUpdating = false;
+
+        return view;
+    }
+
+    private void showDescription(int resId) {
+        Toast.makeText(requireContext(), resId, Toast.LENGTH_SHORT).show();
+    }
+
+    private void addWatcher(EditText editText, Unit unit) {
+        editText.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
+
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {}
+
+            @Override
+            public void afterTextChanged(Editable s) {
+                if (isUpdating) return;
+                String text = s.toString();
+                if (text.isEmpty() || text.equals("-") || text.equals(".") || text.equals("-.") ) {
+                    return;
+                }
+                try {
+                    double value = Double.parseDouble(text);
+                    int precision = Math.max(getPrecision(text), 3);
+                    isUpdating = true;
+                    double kg = toKilogram(unit, value);
+                    if (kg < 0.0) {
+                        Toast.makeText(requireContext(), R.string.warn_negative_mass, Toast.LENGTH_SHORT).show();
+                        kg = 0.0;
+                        setAll(kg, precision);
+                    } else {
+                        setText(kilogram, fromKilogram(Unit.KILOGRAM, kg), precision, unit == Unit.KILOGRAM);
+                        setText(gram, fromKilogram(Unit.GRAM, kg), precision, unit == Unit.GRAM);
+                        setText(milligram, fromKilogram(Unit.MILLIGRAM, kg), precision, unit == Unit.MILLIGRAM);
+                        setText(centner, fromKilogram(Unit.CENTNER, kg), precision, unit == Unit.CENTNER);
+                        setText(tonne, fromKilogram(Unit.TONNE, kg), precision, unit == Unit.TONNE);
+                        setText(carat, fromKilogram(Unit.CARAT, kg), precision, unit == Unit.CARAT);
+                        setText(newton, fromKilogram(Unit.NEWTON, kg), precision, unit == Unit.NEWTON);
+                        setText(stone, fromKilogram(Unit.STONE, kg), precision, unit == Unit.STONE);
+                        setText(pound, fromKilogram(Unit.POUND, kg), precision, unit == Unit.POUND);
+                        setText(ounce, fromKilogram(Unit.OUNCE, kg), precision, unit == Unit.OUNCE);
+                        setText(dram, fromKilogram(Unit.DRAM, kg), precision, unit == Unit.DRAM);
+                        setText(grain, fromKilogram(Unit.GRAIN, kg), precision, unit == Unit.GRAIN);
+                        setText(shortTon, fromKilogram(Unit.SHORT_TON, kg), precision, unit == Unit.SHORT_TON);
+                        setText(shortHundredweight, fromKilogram(Unit.SHORT_HUNDREDWEIGHT, kg), precision, unit == Unit.SHORT_HUNDREDWEIGHT);
+                        setText(longTon, fromKilogram(Unit.LONG_TON, kg), precision, unit == Unit.LONG_TON);
+                        setText(longHundredweight, fromKilogram(Unit.LONG_HUNDREDWEIGHT, kg), precision, unit == Unit.LONG_HUNDREDWEIGHT);
+                        setText(troyPound, fromKilogram(Unit.TROY_POUND, kg), precision, unit == Unit.TROY_POUND);
+                        setText(troyOunce, fromKilogram(Unit.TROY_OUNCE, kg), precision, unit == Unit.TROY_OUNCE);
+                        setText(pennyweight, fromKilogram(Unit.PENNYWEIGHT, kg), precision, unit == Unit.PENNYWEIGHT);
+                        setText(mite, fromKilogram(Unit.MITE, kg), precision, unit == Unit.MITE);
+                        setText(doit, fromKilogram(Unit.DOIT, kg), precision, unit == Unit.DOIT);
+                    }
+                } catch (NumberFormatException ignore) {
+                } finally {
+                    isUpdating = false;
+                }
+            }
+        });
+    }
+
+    private void setAll(double kg, int precision) {
+        setText(kilogram, fromKilogram(Unit.KILOGRAM, kg), precision, false);
+        setText(gram, fromKilogram(Unit.GRAM, kg), precision, false);
+        setText(milligram, fromKilogram(Unit.MILLIGRAM, kg), precision, false);
+        setText(centner, fromKilogram(Unit.CENTNER, kg), precision, false);
+        setText(tonne, fromKilogram(Unit.TONNE, kg), precision, false);
+        setText(carat, fromKilogram(Unit.CARAT, kg), precision, false);
+        setText(newton, fromKilogram(Unit.NEWTON, kg), precision, false);
+        setText(stone, fromKilogram(Unit.STONE, kg), precision, false);
+        setText(pound, fromKilogram(Unit.POUND, kg), precision, false);
+        setText(ounce, fromKilogram(Unit.OUNCE, kg), precision, false);
+        setText(dram, fromKilogram(Unit.DRAM, kg), precision, false);
+        setText(grain, fromKilogram(Unit.GRAIN, kg), precision, false);
+        setText(shortTon, fromKilogram(Unit.SHORT_TON, kg), precision, false);
+        setText(shortHundredweight, fromKilogram(Unit.SHORT_HUNDREDWEIGHT, kg), precision, false);
+        setText(longTon, fromKilogram(Unit.LONG_TON, kg), precision, false);
+        setText(longHundredweight, fromKilogram(Unit.LONG_HUNDREDWEIGHT, kg), precision, false);
+        setText(troyPound, fromKilogram(Unit.TROY_POUND, kg), precision, false);
+        setText(troyOunce, fromKilogram(Unit.TROY_OUNCE, kg), precision, false);
+        setText(pennyweight, fromKilogram(Unit.PENNYWEIGHT, kg), precision, false);
+        setText(mite, fromKilogram(Unit.MITE, kg), precision, false);
+        setText(doit, fromKilogram(Unit.DOIT, kg), precision, false);
+    }
+
+    private void setText(EditText edit, double value, int precision, boolean isSource) {
+        if (isSource) return;
+        edit.setText(format(value, precision));
+    }
+
+    private String format(double value, int precision) {
+        BigDecimal bd = new BigDecimal(value);
+        bd = bd.setScale(precision, RoundingMode.HALF_UP);
+        return bd.toPlainString();
+    }
+
+    private int getPrecision(String text) {
+        int idx = text.indexOf('.');
+        return idx >= 0 ? text.length() - idx - 1 : 0;
+    }
+
+    private double toKilogram(Unit unit, double value) {
+        switch (unit) {
+            case KILOGRAM:
+                return value;
+            case GRAM:
+                return value / 1_000.0;
+            case MILLIGRAM:
+                return value / 1_000_000.0;
+            case CENTNER:
+                return value * 100.0;
+            case TONNE:
+                return value * 1_000.0;
+            case CARAT:
+                return value * 0.0002;
+            case NEWTON:
+                return value / 9.80665;
+            case STONE:
+                return value * 6.35029318;
+            case POUND:
+                return value * 0.45359237;
+            case OUNCE:
+                return value * 0.028349523125;
+            case DRAM:
+                return value * 0.0017718451953125;
+            case GRAIN:
+                return value * 0.00006479891;
+            case SHORT_TON:
+                return value * 907.18474;
+            case SHORT_HUNDREDWEIGHT:
+                return value * 45.359237;
+            case LONG_TON:
+                return value * 1_016.0469088;
+            case LONG_HUNDREDWEIGHT:
+                return value * 50.80234544;
+            case TROY_POUND:
+                return value * 0.3732417216;
+            case TROY_OUNCE:
+                return value * 0.0311034768;
+            case PENNYWEIGHT:
+                return value * 0.00155517384;
+            case MITE:
+                return value * 0.00000269995458;
+            case DOIT:
+                return value * 0.000000112497724;
+        }
+        return value;
+    }
+
+    private double fromKilogram(Unit unit, double kilogram) {
+        switch (unit) {
+            case KILOGRAM:
+                return kilogram;
+            case GRAM:
+                return kilogram * 1_000.0;
+            case MILLIGRAM:
+                return kilogram * 1_000_000.0;
+            case CENTNER:
+                return kilogram / 100.0;
+            case TONNE:
+                return kilogram / 1_000.0;
+            case CARAT:
+                return kilogram * 5_000.0;
+            case NEWTON:
+                return kilogram * 9.80665;
+            case STONE:
+                return kilogram / 6.35029318;
+            case POUND:
+                return kilogram / 0.45359237;
+            case OUNCE:
+                return kilogram / 0.028349523125;
+            case DRAM:
+                return kilogram / 0.0017718451953125;
+            case GRAIN:
+                return kilogram / 0.00006479891;
+            case SHORT_TON:
+                return kilogram / 907.18474;
+            case SHORT_HUNDREDWEIGHT:
+                return kilogram / 45.359237;
+            case LONG_TON:
+                return kilogram / 1_016.0469088;
+            case LONG_HUNDREDWEIGHT:
+                return kilogram / 50.80234544;
+            case TROY_POUND:
+                return kilogram / 0.3732417216;
+            case TROY_OUNCE:
+                return kilogram / 0.0311034768;
+            case PENNYWEIGHT:
+                return kilogram / 0.00155517384;
+            case MITE:
+                return kilogram / 0.00000269995458;
+            case DOIT:
+                return kilogram / 0.000000112497724;
+        }
+        return kilogram;
+    }
+}

--- a/app/src/main/java/ru/sergeipavlov/metrology/UnitsActivity.java
+++ b/app/src/main/java/ru/sergeipavlov/metrology/UnitsActivity.java
@@ -36,6 +36,8 @@ public class UnitsActivity extends BaseActivity {
             Class<?> activity = null;
             if (i == 0) {
                 activity = TimeActivity.class;
+            } else if (i == 2) {
+                activity = MassActivity.class;
             } else if (i == 3) {
                 activity = CurrentActivity.class;
             } else if (i == 4) {

--- a/app/src/main/res/layout/activity_mass.xml
+++ b/app/src/main/res/layout/activity_mass.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/mass_container"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent" />

--- a/app/src/main/res/layout/fragment_mass.xml
+++ b/app/src/main/res/layout/fragment_mass.xml
@@ -1,0 +1,522 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="16dp">
+
+        <TextView
+            android:id="@+id/si_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/base_units_title"
+            android:textStyle="bold"
+            android:paddingBottom="8dp" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:paddingBottom="16dp">
+            <EditText
+                android:id="@+id/edit_kilogram"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:inputType="numberDecimal|numberSigned" />
+            <TextView
+                android:id="@+id/symbol_kilogram"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:clickable="true"
+                android:focusable="true"
+                android:paddingStart="8dp"
+                android:text="kg" />
+        </LinearLayout>
+
+        <TextView
+            android:id="@+id/derived_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/derived_units_title"
+            android:textStyle="bold"
+            android:paddingBottom="8dp" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:paddingBottom="8dp">
+            <EditText
+                android:id="@+id/edit_gram"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:inputType="numberDecimal|numberSigned" />
+            <TextView
+                android:id="@+id/symbol_gram"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:clickable="true"
+                android:focusable="true"
+                android:paddingStart="8dp"
+                android:text="g" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:paddingBottom="8dp">
+            <EditText
+                android:id="@+id/edit_milligram"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:inputType="numberDecimal|numberSigned" />
+            <TextView
+                android:id="@+id/symbol_milligram"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:clickable="true"
+                android:focusable="true"
+                android:paddingStart="8dp"
+                android:text="mg" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:paddingBottom="8dp">
+            <EditText
+                android:id="@+id/edit_centner"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:inputType="numberDecimal|numberSigned" />
+            <TextView
+                android:id="@+id/symbol_centner"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:clickable="true"
+                android:focusable="true"
+                android:paddingStart="8dp"
+                android:text="q" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:paddingBottom="8dp">
+            <EditText
+                android:id="@+id/edit_tonne"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:inputType="numberDecimal|numberSigned" />
+            <TextView
+                android:id="@+id/symbol_tonne"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:clickable="true"
+                android:focusable="true"
+                android:paddingStart="8dp"
+                android:text="t" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:paddingBottom="8dp">
+            <EditText
+                android:id="@+id/edit_carat"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:inputType="numberDecimal|numberSigned" />
+            <TextView
+                android:id="@+id/symbol_carat"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:clickable="true"
+                android:focusable="true"
+                android:paddingStart="8dp"
+                android:text="ct" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:paddingBottom="8dp">
+            <EditText
+                android:id="@+id/edit_newton"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:inputType="numberDecimal|numberSigned" />
+            <TextView
+                android:id="@+id/symbol_newton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:clickable="true"
+                android:focusable="true"
+                android:paddingStart="8dp"
+                android:text="N" />
+        </LinearLayout>
+
+        <TextView
+            android:id="@+id/us_uk_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/mass_us_uk_title"
+            android:textStyle="bold"
+            android:paddingBottom="8dp" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:paddingBottom="8dp">
+            <EditText
+                android:id="@+id/edit_stone"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:inputType="numberDecimal|numberSigned" />
+            <TextView
+                android:id="@+id/symbol_stone"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:clickable="true"
+                android:focusable="true"
+                android:paddingStart="8dp"
+                android:text="st" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:paddingBottom="8dp">
+            <EditText
+                android:id="@+id/edit_pound"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:inputType="numberDecimal|numberSigned" />
+            <TextView
+                android:id="@+id/symbol_pound"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:clickable="true"
+                android:focusable="true"
+                android:paddingStart="8dp"
+                android:text="lb" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:paddingBottom="8dp">
+            <EditText
+                android:id="@+id/edit_ounce"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:inputType="numberDecimal|numberSigned" />
+            <TextView
+                android:id="@+id/symbol_ounce"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:clickable="true"
+                android:focusable="true"
+                android:paddingStart="8dp"
+                android:text="oz" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:paddingBottom="8dp">
+            <EditText
+                android:id="@+id/edit_dram"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:inputType="numberDecimal|numberSigned" />
+            <TextView
+                android:id="@+id/symbol_dram"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:clickable="true"
+                android:focusable="true"
+                android:paddingStart="8dp"
+                android:text="dr" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:paddingBottom="8dp">
+            <EditText
+                android:id="@+id/edit_grain"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:inputType="numberDecimal|numberSigned" />
+            <TextView
+                android:id="@+id/symbol_grain"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:clickable="true"
+                android:focusable="true"
+                android:paddingStart="8dp"
+                android:text="gr" />
+        </LinearLayout>
+
+        <TextView
+            android:id="@+id/us_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/mass_us_title"
+            android:textStyle="bold"
+            android:paddingBottom="8dp" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:paddingBottom="8dp">
+            <EditText
+                android:id="@+id/edit_short_ton"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:inputType="numberDecimal|numberSigned" />
+            <TextView
+                android:id="@+id/symbol_short_ton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:clickable="true"
+                android:focusable="true"
+                android:paddingStart="8dp"
+                android:text="tn (US)" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:paddingBottom="8dp">
+            <EditText
+                android:id="@+id/edit_short_hundredweight"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:inputType="numberDecimal|numberSigned" />
+            <TextView
+                android:id="@+id/symbol_short_hundredweight"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:clickable="true"
+                android:focusable="true"
+                android:paddingStart="8dp"
+                android:text="cwt (US)" />
+        </LinearLayout>
+
+        <TextView
+            android:id="@+id/uk_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/mass_uk_title"
+            android:textStyle="bold"
+            android:paddingBottom="8dp" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:paddingBottom="8dp">
+            <EditText
+                android:id="@+id/edit_long_ton"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:inputType="numberDecimal|numberSigned" />
+            <TextView
+                android:id="@+id/symbol_long_ton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:clickable="true"
+                android:focusable="true"
+                android:paddingStart="8dp"
+                android:text="tn (UK)" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:paddingBottom="8dp">
+            <EditText
+                android:id="@+id/edit_long_hundredweight"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:inputType="numberDecimal|numberSigned" />
+            <TextView
+                android:id="@+id/symbol_long_hundredweight"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:clickable="true"
+                android:focusable="true"
+                android:paddingStart="8dp"
+                android:text="cwt (UK)" />
+        </LinearLayout>
+
+        <TextView
+            android:id="@+id/troy_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/mass_troy_title"
+            android:textStyle="bold"
+            android:paddingBottom="8dp" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:paddingBottom="8dp">
+            <EditText
+                android:id="@+id/edit_troy_pound"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:inputType="numberDecimal|numberSigned" />
+            <TextView
+                android:id="@+id/symbol_troy_pound"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:clickable="true"
+                android:focusable="true"
+                android:paddingStart="8dp"
+                android:text="lb t" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:paddingBottom="8dp">
+            <EditText
+                android:id="@+id/edit_troy_ounce"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:inputType="numberDecimal|numberSigned" />
+            <TextView
+                android:id="@+id/symbol_troy_ounce"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:clickable="true"
+                android:focusable="true"
+                android:paddingStart="8dp"
+                android:text="oz t" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:paddingBottom="8dp">
+            <EditText
+                android:id="@+id/edit_pennyweight"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:inputType="numberDecimal|numberSigned" />
+            <TextView
+                android:id="@+id/symbol_pennyweight"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:clickable="true"
+                android:focusable="true"
+                android:paddingStart="8dp"
+                android:text="dwt" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:paddingBottom="8dp">
+            <EditText
+                android:id="@+id/edit_mite"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:inputType="numberDecimal|numberSigned" />
+            <TextView
+                android:id="@+id/symbol_mite"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:clickable="true"
+                android:focusable="true"
+                android:paddingStart="8dp"
+                android:text="mite" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical">
+            <EditText
+                android:id="@+id/edit_doit"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:inputType="numberDecimal|numberSigned" />
+            <TextView
+                android:id="@+id/symbol_doit"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:clickable="true"
+                android:focusable="true"
+                android:paddingStart="8dp"
+                android:text="doit" />
+        </LinearLayout>
+
+    </LinearLayout>
+</ScrollView>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -54,6 +54,33 @@
     <string name="desc_millennium">Тысячагоддзе — 1000 гадоў.</string>
     <string name="warn_negative_time">Час не можа быць адмоўным</string>
 
+    <string name="desc_kilogram">Кілаграм — адзінка масы СІ.</string>
+    <string name="desc_gram">Грам — адна тысячная кілаграма.</string>
+    <string name="desc_milligram">Міліграм — адна мільённая кілаграма.</string>
+    <string name="desc_centner">Метрычны цэнтнер роўны 100 кілаграмам.</string>
+    <string name="desc_tonne">Тона роўная 1000 кілаграмам.</string>
+    <string name="desc_carat">Карат роўны 200 міліграмам.</string>
+    <string name="desc_newton_force">Ньютан — адзінка сілы; маса вызначаецца як N/9,80665.</string>
+    <string name="desc_stone">Стоун — брытанская адзінка, роўная 14 фунтам (≈6,35 кг).</string>
+    <string name="desc_pound">Фунт — адзінка масы ЗША і Брытаніі, роўная 0,45359237 кг.</string>
+    <string name="desc_ounce">Унцыя — 1/16 фунта (≈28,35 г).</string>
+    <string name="desc_dram">Драм — 1/16 унцыі (≈1,77 г).</string>
+    <string name="desc_grain">Гран — 1/7000 фунта (≈64,8 мг).</string>
+    <string name="desc_short_ton">Кароткая тона (ЗША) — 2000 фунтаў (≈907 кг).</string>
+    <string name="desc_short_hundredweight">Кароткі цэнтнер (ЗША) — 100 фунтаў (≈45,36 кг).</string>
+    <string name="desc_long_ton">Доўгая тона (Брытанія) — 2240 фунтаў (≈1016 кг).</string>
+    <string name="desc_long_hundredweight">Доўгі цэнтнер (Брытанія) — 112 фунтаў (≈50,8 кг).</string>
+    <string name="desc_troy_pound">Тройскі фунт — 12 тройскіх унцый (≈0,373 кг).</string>
+    <string name="desc_troy_ounce">Тройская унцыя — 31,1034768 г.</string>
+    <string name="desc_pennyweight">Пеніўейт — 1/20 тройскай унцыі (≈1,555 г).</string>
+    <string name="desc_mite">Майт — 1/24 грана (≈0,0027 г).</string>
+    <string name="desc_doit">Дойт — 1/24 майта (≈0,00011 г).</string>
+    <string name="mass_us_uk_title">ЗША і Брытанія</string>
+    <string name="mass_us_title">ЗША</string>
+    <string name="mass_uk_title">Брытанія</string>
+    <string name="mass_troy_title">Тройская сістэма</string>
+    <string name="warn_negative_mass">Маса не можа быць адмоўнай</string>
+
     <string name="settings_title">Налады</string>
     <string name="pref_language">Мова</string>
     <string name="pref_theme">Тэма</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -54,6 +54,33 @@
     <string name="desc_millennium">Millennium is 1000 years.</string>
     <string name="warn_negative_time">Time cannot be negative</string>
 
+    <string name="desc_kilogram">Kilogram is the SI unit of mass.</string>
+    <string name="desc_gram">Gram is one thousandth of a kilogram.</string>
+    <string name="desc_milligram">Milligram is one millionth of a kilogram.</string>
+    <string name="desc_centner">Metric centner equals 100 kilograms.</string>
+    <string name="desc_tonne">Tonne equals 1000 kilograms.</string>
+    <string name="desc_carat">Carat equals 200 milligrams.</string>
+    <string name="desc_newton_force">Newton is the SI unit of force; mass is N/9.80665.</string>
+    <string name="desc_stone">Stone is a British unit equal to 14 pounds (≈6.35 kg).</string>
+    <string name="desc_pound">Pound is a US and UK unit equal to 0.45359237 kg.</string>
+    <string name="desc_ounce">Ounce is 1/16 of a pound (≈28.35 g).</string>
+    <string name="desc_dram">Dram is 1/16 of an ounce (≈1.77 g).</string>
+    <string name="desc_grain">Grain is 1/7000 of a pound (≈64.8 mg).</string>
+    <string name="desc_short_ton">Short ton (US) is 2000 pounds (≈907 kg).</string>
+    <string name="desc_short_hundredweight">Short hundredweight (US) is 100 pounds (≈45.36 kg).</string>
+    <string name="desc_long_ton">Long ton (UK) is 2240 pounds (≈1016 kg).</string>
+    <string name="desc_long_hundredweight">Long hundredweight (UK) is 112 pounds (≈50.8 kg).</string>
+    <string name="desc_troy_pound">Troy pound is 12 troy ounces (≈0.373 kg).</string>
+    <string name="desc_troy_ounce">Troy ounce equals 31.1034768 g.</string>
+    <string name="desc_pennyweight">Pennyweight is 1/20 of a troy ounce (≈1.555 g).</string>
+    <string name="desc_mite">Mite is 1/24 of a grain (≈0.0027 g).</string>
+    <string name="desc_doit">Doit is 1/24 of a mite (≈0.00011 g).</string>
+    <string name="mass_us_uk_title">US and Britain</string>
+    <string name="mass_us_title">US</string>
+    <string name="mass_uk_title">Britain</string>
+    <string name="mass_troy_title">Troy system</string>
+    <string name="warn_negative_mass">Mass cannot be negative</string>
+
     <string name="settings_title">Settings</string>
     <string name="pref_language">Language</string>
     <string name="pref_theme">Theme</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -54,6 +54,33 @@
     <string name="desc_millennium">Тысячелетие — 1000 лет.</string>
     <string name="warn_negative_time">Время не может быть отрицательным</string>
 
+    <string name="desc_kilogram">Килограмм — единица массы СИ.</string>
+    <string name="desc_gram">Грамм — одна тысячная килограмма.</string>
+    <string name="desc_milligram">Миллиграмм — одна миллионная килограмма.</string>
+    <string name="desc_centner">Метрический центнер равен 100 килограммам.</string>
+    <string name="desc_tonne">Тонна равна 1000 килограммам.</string>
+    <string name="desc_carat">Карат равен 200 миллиграммам.</string>
+    <string name="desc_newton_force">Ньютон — единица силы; масса определяется как N/9,80665.</string>
+    <string name="desc_stone">Стоун — британская единица, равная 14 фунтам (≈6,35 кг).</string>
+    <string name="desc_pound">Фунт — единица массы США и Британии, равная 0,45359237 кг.</string>
+    <string name="desc_ounce">Унция — 1/16 фунта (≈28,35 г).</string>
+    <string name="desc_dram">Драм — 1/16 унции (≈1,77 г).</string>
+    <string name="desc_grain">Гран — 1/7000 фунта (≈64,8 мг).</string>
+    <string name="desc_short_ton">Короткая тонна (США) — 2000 фунтов (≈907 кг).</string>
+    <string name="desc_short_hundredweight">Короткий центнер (США) — 100 фунтов (≈45,36 кг).</string>
+    <string name="desc_long_ton">Длинная тонна (Британия) — 2240 фунтов (≈1016 кг).</string>
+    <string name="desc_long_hundredweight">Длинный центнер (Британия) — 112 фунтов (≈50,8 кг).</string>
+    <string name="desc_troy_pound">Тройский фунт — 12 тройских унций (≈0,373 кг).</string>
+    <string name="desc_troy_ounce">Тройская унция — 31,1034768 г.</string>
+    <string name="desc_pennyweight">Пеннивейт — 1/20 тройской унции (≈1,555 г).</string>
+    <string name="desc_mite">Майт — 1/24 грана (≈0,0027 г).</string>
+    <string name="desc_doit">Дойт — 1/24 майта (≈0,00011 г).</string>
+    <string name="mass_us_uk_title">США и Британия</string>
+    <string name="mass_us_title">США</string>
+    <string name="mass_uk_title">Британия</string>
+    <string name="mass_troy_title">Тройская система</string>
+    <string name="warn_negative_mass">Масса не может быть отрицательной</string>
+
     <string name="settings_title">Настройки</string>
     <string name="pref_language">Язык</string>
     <string name="pref_theme">Тема</string>


### PR DESCRIPTION
## Summary
- Add MassActivity and MassFragment to convert between kilogram, SI derived units, US/UK, and troy weight units
- Wire up mass screen in units menu and register activity in manifest
- Provide localized descriptions and negative mass warning

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ecb48c948320bcbf3987c5918fde