### PR TITLE
Handle RecyclerView NO_POSITION in MainAdapter

### DIFF
--- a/app/src/main/java/ru/sergeipavlov/metrology/MainAdapter.java
+++ b/app/src/main/java/ru/sergeipavlov/metrology/MainAdapter.java
@@ -31,6 +31,9 @@ public class MainAdapter extends RecyclerView.Adapter<MainAdapter.ViewHolder> {
         holder.textView.setText(items.get(position));
         holder.itemView.setOnClickListener(v -> {
             int pos = holder.getBindingAdapterPosition();
+            if (pos == RecyclerView.NO_POSITION) {
+                return;
+            }
             if (pos == 0) {
                 v.getContext().startActivity(new Intent(v.getContext(), UnitsActivity.class));
             } else if (pos == 1) {


### PR DESCRIPTION
## Summary
- guard MainAdapter click handler against RecyclerView.NO_POSITION to avoid crashes when the adapter position is invalid

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc273e507c8320a0e26272f3000ca8