### PR TITLE
Add frequency conversion screen

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -39,6 +39,9 @@
             android:name=".CurrentActivity"
             android:exported="false" />
         <activity
+            android:name=".FrequencyActivity"
+            android:exported="false" />
+        <activity
             android:name=".TimeActivity"
             android:exported="false" />
         <activity

--- a/app/src/main/java/ru/sergeipavlov/metrology/FrequencyActivity.java
+++ b/app/src/main/java/ru/sergeipavlov/metrology/FrequencyActivity.java
@@ -1,0 +1,20 @@
+package ru.sergeipavlov.metrology;
+
+import android.os.Bundle;
+
+import androidx.activity.EdgeToEdge;
+
+public class FrequencyActivity extends BaseActivity {
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        EdgeToEdge.enable(this);
+        setContentView(R.layout.activity_frequency);
+        if (savedInstanceState == null) {
+            getSupportFragmentManager()
+                    .beginTransaction()
+                    .replace(R.id.frequency_container, new FrequencyFragment())
+                    .commit();
+        }
+    }
+}

--- a/app/src/main/java/ru/sergeipavlov/metrology/FrequencyFragment.java
+++ b/app/src/main/java/ru/sergeipavlov/metrology/FrequencyFragment.java
@@ -1,0 +1,151 @@
+package ru.sergeipavlov.metrology;
+
+import android.os.Bundle;
+import android.text.Editable;
+import android.text.TextWatcher;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.EditText;
+import android.widget.Toast;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+public class FrequencyFragment extends Fragment {
+    private EditText hertz;
+    private EditText kilohertz;
+    private EditText megahertz;
+    private EditText gigahertz;
+    private boolean isUpdating;
+
+    private enum Unit {HERTZ, KILOHERTZ, MEGAHERTZ, GIGAHERTZ}
+
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+        View view = inflater.inflate(R.layout.fragment_frequency, container, false);
+        hertz = view.findViewById(R.id.edit_hertz);
+        kilohertz = view.findViewById(R.id.edit_kilohertz);
+        megahertz = view.findViewById(R.id.edit_megahertz);
+        gigahertz = view.findViewById(R.id.edit_gigahertz);
+
+        view.findViewById(R.id.symbol_hertz).setOnClickListener(v -> showDescription(R.string.desc_hertz));
+        view.findViewById(R.id.symbol_kilohertz).setOnClickListener(v -> showDescription(R.string.desc_kilohertz));
+        view.findViewById(R.id.symbol_megahertz).setOnClickListener(v -> showDescription(R.string.desc_megahertz));
+        view.findViewById(R.id.symbol_gigahertz).setOnClickListener(v -> showDescription(R.string.desc_gigahertz));
+
+        addWatcher(hertz, Unit.HERTZ);
+        addWatcher(kilohertz, Unit.KILOHERTZ);
+        addWatcher(megahertz, Unit.MEGAHERTZ);
+        addWatcher(gigahertz, Unit.GIGAHERTZ);
+
+        isUpdating = true;
+        double hz = 0.0;
+        int precision = 0;
+        setText(hertz, fromHertz(Unit.HERTZ, hz), precision, false);
+        setText(kilohertz, fromHertz(Unit.KILOHERTZ, hz), precision, false);
+        setText(megahertz, fromHertz(Unit.MEGAHERTZ, hz), precision, false);
+        setText(gigahertz, fromHertz(Unit.GIGAHERTZ, hz), precision, false);
+        isUpdating = false;
+
+        return view;
+    }
+
+    private void showDescription(int resId) {
+        Toast.makeText(requireContext(), resId, Toast.LENGTH_SHORT).show();
+    }
+
+    private void addWatcher(EditText editText, Unit unit) {
+        editText.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
+
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {}
+
+            @Override
+            public void afterTextChanged(Editable s) {
+                if (isUpdating) return;
+                String text = s.toString();
+                if (text.isEmpty() || text.equals("-") || text.equals(".") || text.equals("-.") ) {
+                    return;
+                }
+                try {
+                    double value = Double.parseDouble(text);
+                    int precision = Math.max(getPrecision(text), 3);
+                    isUpdating = true;
+                    double hz = toHertz(unit, value);
+                    if (hz < 0.0) {
+                        Toast.makeText(requireContext(), R.string.warn_negative_frequency, Toast.LENGTH_SHORT).show();
+                        hz = 0.0;
+                        setAll(hz, precision);
+                    } else {
+                        setText(hertz, fromHertz(Unit.HERTZ, hz), precision, unit == Unit.HERTZ);
+                        setText(kilohertz, fromHertz(Unit.KILOHERTZ, hz), precision, unit == Unit.KILOHERTZ);
+                        setText(megahertz, fromHertz(Unit.MEGAHERTZ, hz), precision, unit == Unit.MEGAHERTZ);
+                        setText(gigahertz, fromHertz(Unit.GIGAHERTZ, hz), precision, unit == Unit.GIGAHERTZ);
+                    }
+                } catch (NumberFormatException ignore) {
+                } finally {
+                    isUpdating = false;
+                }
+            }
+        });
+    }
+
+    private void setAll(double hz, int precision) {
+        setText(hertz, fromHertz(Unit.HERTZ, hz), precision, false);
+        setText(kilohertz, fromHertz(Unit.KILOHERTZ, hz), precision, false);
+        setText(megahertz, fromHertz(Unit.MEGAHERTZ, hz), precision, false);
+        setText(gigahertz, fromHertz(Unit.GIGAHERTZ, hz), precision, false);
+    }
+
+    private void setText(EditText edit, double value, int precision, boolean isSource) {
+        if (isSource) return;
+        edit.setText(format(value, precision));
+    }
+
+    private String format(double value, int precision) {
+        BigDecimal bd = new BigDecimal(value);
+        bd = bd.setScale(precision, RoundingMode.HALF_UP);
+        return bd.toPlainString();
+    }
+
+    private int getPrecision(String text) {
+        int idx = text.indexOf('.');
+        return idx >= 0 ? text.length() - idx - 1 : 0;
+    }
+
+    private double toHertz(Unit unit, double value) {
+        switch (unit) {
+            case HERTZ:
+                return value;
+            case KILOHERTZ:
+                return value * 1_000.0;
+            case MEGAHERTZ:
+                return value * 1_000_000.0;
+            case GIGAHERTZ:
+                return value * 1_000_000_000.0;
+        }
+        return value;
+    }
+
+    private double fromHertz(Unit unit, double hertz) {
+        switch (unit) {
+            case HERTZ:
+                return hertz;
+            case KILOHERTZ:
+                return hertz / 1_000.0;
+            case MEGAHERTZ:
+                return hertz / 1_000_000.0;
+            case GIGAHERTZ:
+                return hertz / 1_000_000_000.0;
+        }
+        return hertz;
+    }
+}

--- a/app/src/main/java/ru/sergeipavlov/metrology/UnitsActivity.java
+++ b/app/src/main/java/ru/sergeipavlov/metrology/UnitsActivity.java
@@ -48,8 +48,13 @@ public class UnitsActivity extends BaseActivity {
             items.add(new UnitsAdapter.Item(false, baseUnits[i], activity));
         }
         items.add(new UnitsAdapter.Item(true, getString(R.string.derived_units_title), null));
-        for (String unit : getResources().getStringArray(R.array.derived_units)) {
-            items.add(new UnitsAdapter.Item(false, unit, null));
+        String[] derivedUnits = getResources().getStringArray(R.array.derived_units);
+        for (int i = 0; i < derivedUnits.length; i++) {
+            Class<?> activity = null;
+            if (i == 3) {
+                activity = FrequencyActivity.class;
+            }
+            items.add(new UnitsAdapter.Item(false, derivedUnits[i], activity));
         }
 
         recyclerView.setAdapter(new UnitsAdapter(items));

--- a/app/src/main/res/layout/activity_frequency.xml
+++ b/app/src/main/res/layout/activity_frequency.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/frequency_container"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent" />

--- a/app/src/main/res/layout/fragment_frequency.xml
+++ b/app/src/main/res/layout/fragment_frequency.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="16dp">
+
+        <TextView
+            android:id="@+id/si_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/base_units_title"
+            android:textStyle="bold"
+            android:paddingBottom="8dp" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:paddingBottom="16dp">
+            <EditText
+                android:id="@+id/edit_hertz"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:inputType="numberDecimal|numberSigned" />
+            <TextView
+                android:id="@+id/symbol_hertz"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:clickable="true"
+                android:focusable="true"
+                android:paddingStart="8dp"
+                android:text="Hz" />
+        </LinearLayout>
+
+        <TextView
+            android:id="@+id/derived_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/derived_units_title"
+            android:textStyle="bold"
+            android:paddingBottom="8dp" />
+
+        <!-- Kilohertz -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:paddingBottom="8dp">
+            <EditText
+                android:id="@+id/edit_kilohertz"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:inputType="numberDecimal|numberSigned" />
+            <TextView
+                android:id="@+id/symbol_kilohertz"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:clickable="true"
+                android:focusable="true"
+                android:paddingStart="8dp"
+                android:text="kHz" />
+        </LinearLayout>
+
+        <!-- Megahertz -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:paddingBottom="8dp">
+            <EditText
+                android:id="@+id/edit_megahertz"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:inputType="numberDecimal|numberSigned" />
+            <TextView
+                android:id="@+id/symbol_megahertz"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:clickable="true"
+                android:focusable="true"
+                android:paddingStart="8dp"
+                android:text="MHz" />
+        </LinearLayout>
+
+        <!-- Gigahertz -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical">
+            <EditText
+                android:id="@+id/edit_gigahertz"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:inputType="numberDecimal|numberSigned" />
+            <TextView
+                android:id="@+id/symbol_gigahertz"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:clickable="true"
+                android:focusable="true"
+                android:paddingStart="8dp"
+                android:text="GHz" />
+        </LinearLayout>
+
+    </LinearLayout>
+</ScrollView>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -40,6 +40,11 @@
     <string name="desc_microampere">Мікраампер — адна мільённая частка ампера.</string>
     <string name="desc_milliampere">Міліампер — адна тысячная частка ампера.</string>
     <string name="desc_kiloampere">Кілаампер — тысяча ампер.</string>
+    <string name="desc_hertz">Герц — адзінка частаты СІ.</string>
+    <string name="desc_kilohertz">Кілагерц — тысяча герцаў.</string>
+    <string name="desc_megahertz">Мегагерц — мільён герцаў.</string>
+    <string name="desc_gigahertz">Гігагерц — мільярд герцаў.</string>
+    <string name="warn_negative_frequency">Частата не можа быць адмоўнай</string>
     <string name="warn_below_zero_kelvin">Тэмпература не можа быць ніжэй за абсалютны нуль</string>
     <string name="desc_second">Секунда — адзінка часу СІ.</string>
     <string name="desc_microsecond">Мікрасекунда — адна мільённая доля секунды.</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -39,6 +39,11 @@
     <string name="desc_microampere">Microampere is one millionth of an ampere.</string>
     <string name="desc_milliampere">Milliampere is one thousandth of an ampere.</string>
     <string name="desc_kiloampere">Kiloampere is a thousand amperes.</string>
+    <string name="desc_hertz">The hertz is the SI unit of frequency.</string>
+    <string name="desc_kilohertz">Kilohertz is a thousand hertz.</string>
+    <string name="desc_megahertz">Megahertz is a million hertz.</string>
+    <string name="desc_gigahertz">Gigahertz is a billion hertz.</string>
+    <string name="warn_negative_frequency">Frequency cannot be negative</string>
     <string name="warn_below_zero_kelvin">Temperature cannot be below absolute zero</string>
     <string name="desc_second">The second is the SI unit of time.</string>
     <string name="desc_microsecond">Microsecond is one millionth of a second.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,6 +41,11 @@
     <string name="desc_microampere">Микроампер — одна миллионная часть ампера.</string>
     <string name="desc_milliampere">Миллиампер — одна тысячная часть ампера.</string>
     <string name="desc_kiloampere">Килоампер — тысяча ампер.</string>
+    <string name="desc_hertz">Герц — единица частоты СИ.</string>
+    <string name="desc_kilohertz">Килогерц — тысяча герц.</string>
+    <string name="desc_megahertz">Мегагерц — миллион герц.</string>
+    <string name="desc_gigahertz">Гигагерц — миллиард герц.</string>
+    <string name="warn_negative_frequency">Частота не может быть отрицательной</string>
     <string name="warn_below_zero_kelvin">Температура не может быть ниже абсолютного нуля</string>
     <string name="desc_second">Секунда — единица времени СИ.</string>
     <string name="desc_microsecond">Микросекунда — одна миллионная доля секунды.</string>


### PR DESCRIPTION
## Summary
- add FrequencyActivity and FrequencyFragment to convert hertz, kilohertz, megahertz and gigahertz
- register frequency converter in units list and Android manifest
- localize frequency descriptions and negative frequency warning in Russian, English and Belarusian

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c80c7e6dc08320add6c2c582194490